### PR TITLE
Fix typo in boxware.json

### DIFF
--- a/boxware.json
+++ b/boxware.json
@@ -7,6 +7,6 @@
     "hardware": "t2.medium",
     "folder": "~/Desktop",
     "commands": [
-        "",
+        ""
     ]
 }


### PR DESCRIPTION
Hey guys, found a small typo in this file due to which it wasn't opening on Boxware.